### PR TITLE
cicd: carve out zotpress/** from ReScript anti-pattern policy

### DIFF
--- a/.hypatia-ignore
+++ b/.hypatia-ignore
@@ -1,0 +1,6 @@
+cicd_rules/banned_language_file:zotpress/scripts/build-css.res
+cicd_rules/banned_language_file:zotpress/scripts/build-js.res
+cicd_rules/banned_language_file:zotpress/scripts/build.res
+cicd_rules/banned_language_file:zotpress/src/js/zotpress.res
+cicd_rules/banned_language_file:zotpress/src/rescript/Utils.res
+cicd_rules/banned_language_file:zotpress/src/rescript/Zotpress.res


### PR DESCRIPTION
## Summary

- Add `.hypatia-ignore` with 6 per-file exemptions for `zotpress/**/*.res` under the `cicd_rules/banned_language_file` rule.
- Unblocks PR #18 (`chore: purge nix per 2026-06-01 owner directive`) which is currently red on `governance / Language / package anti-pattern policy` for these 6 grandfathered files that the PR's diff does not touch.

## Rationale

`zotpress/` is a WordPress plugin (`composer.json` `type: wordpress-plugin`) that runs inside the WordPress host runtime — not estate-authored AffineScript-bound application code. The 6 in-tree `.res` files are auto-translated TypeScript placeholders (each carrying `/* Auto-translated placeholder from TypeScript. */`) awaiting the estate-wide ReScript→AffineScript migration umbrella (`hyperpolymath/standards#252`).

The per-file `.hypatia-ignore` mechanism is the workflow's documented escape (`hyperpolymath/standards/.github/workflows/governance-reusable.yml` lines 298-300, `grep -qxF`).

## Files exempted

```
cicd_rules/banned_language_file:zotpress/scripts/build-css.res
cicd_rules/banned_language_file:zotpress/scripts/build-js.res
cicd_rules/banned_language_file:zotpress/scripts/build.res
cicd_rules/banned_language_file:zotpress/src/js/zotpress.res
cicd_rules/banned_language_file:zotpress/src/rescript/Utils.res
cicd_rules/banned_language_file:zotpress/src/rescript/Zotpress.res
```

## Sibling PR

`hyperpolymath/standards` branch `docs/zotpress-rescript-carveout` adds `zotpress/**` to the upstream-fork/WordPress-plugin row of the ReScript Exemptions table in `.claude/CLAUDE.md` (and parallel TS / JS / npm tables) so the estate-wide manifest stays in sync with this per-repo escape.

## Test plan

- [x] Locally replicated workflow logic (`is_exempt()` from governance-reusable.yml:292-305) — all 6 `.res` files report EXEMPT.
- [ ] CI `governance / Language / package anti-pattern policy` job passes on this PR.
- [ ] PR #18 rerun (or next-push) clears the same check.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>