### PR TITLE
fix(ci): clear OSSF Scorecard startup_failure

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,5 +13,8 @@ permissions: read-all
 jobs:
   analysis:
     uses: hyperpolymath/standards/.github/workflows/scorecard-reusable.yml@d7c22711e830e1f383846472f6e9b99debdb201e
-    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
     secrets: inherit


### PR DESCRIPTION
Fixes the OSSF Scorecard workflow, which failed at startup on every run.

**Cause:** reusable-workflow caller missing `security-events: write`+`id-token: write` (reusable perms are capped by the caller), and/or an illegal `timeout-minutes` key on a `uses:` job.

**Fix:** inject caller permissions and/or drop `timeout-minutes`. Pin preserved. Verified with actionlint. Part of an estate-wide Scorecard remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)