### PR TITLE
security: re-pin secret scanner onto the real gitleaks gate

### DIFF
--- a/.github/workflows/secret-scanner.yml
+++ b/.github/workflows/secret-scanner.yml
@@ -13,7 +13,5 @@ jobs:
   scan:
     permissions:
       contents: read
-      pull-requests: write
-      actions: read
-    uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@d135b05bfc647d0c0fbfedc7e80f37ea50f49236
+    uses: hyperpolymath/standards/.github/workflows/secret-scanner-reusable.yml@c65436ee3351cd6b0fa14b142938b195efc77586
     secrets: inherit


### PR DESCRIPTION
This repo's `Secret Scanner` has been reporting **success while being incapable of failing**.

The caller pinned `secret-scanner-reusable` at `@d135b05` (2026-06-24) — **64 commits behind** standards#500. At that pin the step is literally:

```yaml
- name: Gitleaks Secret Scan
  continue-on-error: true          # <- cannot fail
  uses: gitleaks/gitleaks-action@e0c47f4f...
```

Re-pinned to `@c65436ee` (contains #500 — `compare` reports ahead 5 / behind 0):

```yaml
- name: Install gitleaks (pinned + checksum-verified)   # sha256-verified binary
- name: Gitleaks secret scan (gating)
  run: ... gitleaks detect ... --exit-code 1            # gates for real
```

Also narrowed the caller's grant to `contents: read` — the new reusable invokes a binary rather than `gitleaks-action`, so it no longer requests `pull-requests: write` / `actions: read`. (That mismatch is what `startup_failure`d standards' own scanner; see standards#511.)


Verified before opening: `gitleaks detect --exit-code 1` passes on this tree.

Part of the estate-wide sweep of ~200 repos still on the pre-#500 pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)